### PR TITLE
feat: update wasm-pack command and remove display files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,12 +35,9 @@ jobs:
       run: cargo test --verbose
     - name: install wasm-pack
       run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-    - run: wasm-pack build --release --target nodejs
+    - run: wasm-pack build --release --target nodejs --out-name index --out-dir pkg
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: Upload wasm file
+        name: wasm file
         path: pkg/**
-    - name: Display uploaded files
-      run: ls -R
-      shell: bash


### PR DESCRIPTION
使用 upload-artifact 可以将编译后的文档上传到 GitHub Actions，方便在每次提交的时候构建出 WASM 文件。[文档](https://docs.github.com/cn/actions/guides/storing-workflow-data-as-artifacts#uploading-build-and-test-artifacts)