### PR TITLE
feat: performance improvement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ['cdylib']
 
 [dependencies]
-js-sys = "0.3.46"
+js-sys = "0.3.52"
 lyon_algorithms = "0.17.4"
 pathfinder_content = "0.5.0"
 pathfinder_geometry = "0.5.1"
@@ -16,10 +16,16 @@ regex = "1.5.4"
 resvg = { version = "0.15.0", default-features = false }
 tiny-skia = "0.5.1"
 usvg = { version = "0.15.0", default-features = false }
-wasm-bindgen = "0.2.74"
+wasm-bindgen = "0.2.75"
 
+# Doc: https://rustwasm.github.io/book/reference/code-size.html#use-the-wasm-opt-tool
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ["-O3"] # Optimize aggressively for speed.
+
+# Default profiles: https://doc.rust-lang.org/cargo/reference/profiles.html#default-profiles
 [profile.release]
-lto = true
-
-# Tell `rustc` to optimize for small code size.
-opt-level = "s"
+lto = true # Enable Link Time Optimization
+opt-level = 3
+# Setting this to 1 may improve the performance of generated code, but may be slower to compile.
+# https://doc.rust-lang.org/rustc/codegen-options/index.html#codegen-units
+codegen-units = 1


### PR DESCRIPTION
通过升级 resvg 0.15.0 性能上有很大的提示，这个 PR 通过优化编译参数，进一步提升性能，但牺牲了一些编译时间和增加 `wasm` 文件体积。

Fixes #12 

```shell
wasm-pack build --release --target nodejs --out-name index --out-dir pkg
```

在生成图片尺寸为 900px `.render(900)` 时的测试结果如下：

测试 SVG: https://iconfont.alicdn.com/t/fde3869d-4282-4067-9bc8-25328c558f18_origin.svg

优化方式 | wasm 文件体积 | 耗时 | 编译时间
-- | -- | -- | --
opt-level = "s", codegen-units = 16 | 1,671,289 字节 | 3391 ms | 11.86s
opt-level = 3,codegen-units = 16 | 1,979,951 字节 | 3410 ms | 49.55s
opt-level = "s", codegen-units = 1 | 1,636,412 字节 | 2613 ms | 28.10s
opt-level = 3, codegen-units = 1 | 1,956,108 字节 | 2272 ms | 16.81s

这个 PR 选择了第四种方式。