### PR TITLE
Upgrade resvg to 0.16.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,10 @@ lyon_algorithms = "0.17.4"
 pathfinder_content = "0.5.0"
 pathfinder_geometry = "0.5.1"
 regex = "1.5.4"
-resvg = { version = "0.15.0", default-features = false }
-tiny-skia = "0.5.1"
-usvg = { version = "0.15.0", default-features = false }
+resvg = { version = "0.16.0", default-features = false }
+tiny-skia = "0.6.0"
+usvg = { version = "0.16.0", default-features = false }
+svgtypes = "0.6.0"
 wasm-bindgen = "0.2.75"
 
 # Doc: https://rustwasm.github.io/book/reference/code-size.html#use-the-wasm-opt-tool

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,8 @@ pub struct RustySvg {
 impl RustySvg {
     #[wasm_bindgen(constructor)]
     pub fn new(svg: &str) -> RustySvg {
-        let tree = usvg::Tree::from_str(svg, &usvg::Options::default()).unwrap();
+        let opt = usvg::Options::default();
+        let tree = usvg::Tree::from_str(svg, &opt.to_ref()).unwrap();
         let mut svg = RustySvg { tree };
         svg.apply_transform();
         svg


### PR DESCRIPTION
Other dependencies are also upgraded to the latest version.