### PR TITLE
feat: add get_bbox()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ['cdylib']
 
 [dependencies]
-js-sys = "0.3.52"
+js-sys = "0.3.53"
 lyon_algorithms = "0.17.4"
 pathfinder_content = "0.5.0"
 pathfinder_geometry = "0.5.1"
@@ -16,8 +16,8 @@ regex = "1.5.4"
 resvg = { version = "0.16.0", default-features = false }
 tiny-skia = "0.6.0"
 usvg = { version = "0.16.0", default-features = false }
-svgtypes = "0.6.0"
 wasm-bindgen = "0.2.75"
+web-sys = { version="0.3.53", features=[ "console" ] }
 
 # Doc: https://rustwasm.github.io/book/reference/code-size.html#use-the-wasm-opt-tool
 [package.metadata.wasm-pack.profile.release]


### PR DESCRIPTION
Calculate SVG bbox, like SVGGraphicsElement.getBBox() DOM API.