### PR TITLE
feat: Upgrade resvg to 0.17.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,10 @@ lyon_algorithms = "0.17.4"
 pathfinder_content = "0.5.0"
 pathfinder_geometry = "0.5.1"
 regex = "1.5.4"
-resvg = { version = "0.16.0", default-features = false }
+resvg = { version = "0.17.0", default-features = false }
 tiny-skia = "0.6.0"
-usvg = { version = "0.16.0", default-features = false }
-svgtypes = "0.6.0"
+usvg = { version = "0.17.0", default-features = false, features=[ "export" ] }
+svgtypes = "0.7.0"
 wasm-bindgen = "0.2.75"
 
 # Doc: https://rustwasm.github.io/book/reference/code-size.html#use-the-wasm-opt-tool


### PR DESCRIPTION
`usvg::Tree::to_string` is behind the export build feature now.